### PR TITLE
Add millvalleycabin.com (lowercase) to Custom urls

### DIFF
--- a/tsml_react.php
+++ b/tsml_react.php
@@ -11,6 +11,7 @@ add_shortcode('tsml_react', function() {
         'sites.google.com' => 'Custom',
         'tinyurl.com' => 'Custom',
         'MillValleyCabin.com' => 'Custom',
+        'millvalleycabin.com' => 'Custom',
         'drydocksf.org' => 'Custom',
     ];
     $is_local = substr(get_site_url(), -5) == '.test';


### PR DESCRIPTION
Currently only supported for MillValleyCabin.com. Don't want our Airtable admins to have to remember to capitalize. Custom links for these meetings have been down for a few days as a result of this.